### PR TITLE
Fix Windows build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ ALL_OBJECTS := $(C_OBJECTS) $(ASM_OBJECTS)
 SUBDIRS := $(sort $(dir $(ALL_OBJECTS)))
 
 ifeq ($(OS),Windows_NT)
-LIB := ../../tools/agbcc/lib/libc.a ../../tools/agbcc/lib/libgcc.a
+LIB := ../../tools/agbcc/lib/libc.a ../../tools/agbcc/lib/libgcc.a ../../libagbsyscall/libagbsyscall.a
 else
 LIB := -L ../../tools/agbcc/lib -lc -lgcc -L ../../libagbsyscall -lagbsyscall 
 endif


### PR DESCRIPTION
Makefile forgot to include libagbsyscall in the Windows build, causing CpuSet/SoundBiasReset/VBlankIntrWait calls to fail the build