### PR TITLE
Improve calcrom

### DIFF
--- a/data/sound_data.s
+++ b/data/sound_data.s
@@ -5,4 +5,4 @@
 	.include "sound/music_player_table.inc"
 	.include "sound/song_table.inc"
 
-	.incbin "baserom.gba", 0x1E8841C
+	.incbin "baserom.gba", 0x1E8841C, 0x177BE4


### PR DESCRIPTION
Add incbin counting, fix a few existing issues, such as double-discounting symbols not within certain address ranges and `nullsub_` subroutines.

The command for finding assembly files for `.incbin` searching is a bit janky, but works. The previous version crashed if `vim` was left open while performing a search, because of the binary swapfile.