### PR TITLE
Fix a lot of nonmatchings

### DIFF
--- a/src/code_80118A4.c
+++ b/src/code_80118A4.c
@@ -178,10 +178,7 @@ u32 sub_8011940(u16 r0)
     temp = sub_800C068();
 
     if(r0 == 999)
-    {
-        temp ^= 999;
-        return (-temp | temp) >> 31;
-    }
+        return temp != 999;
 
     return temp == r0;
 }

--- a/src/code_80118A4.c
+++ b/src/code_80118A4.c
@@ -27,11 +27,11 @@ extern void nullsub_28(void);
 
 extern int sprintf(char *, const char *, ...);
 
-struct unkFileStruct
+struct DebugLocation
 {
-    u32 unk0;
-    u32 unk4;
-    u32 unk8;
+    char *file;
+    u32 line;
+    char *func;
 };
 
 
@@ -41,9 +41,9 @@ extern s16 gUnknown_202DE22;
 extern s16 gUnknown_202DE24;
 extern u32 gUnknown_202DE1C;
 extern u32 gUnknown_203B14C;
-extern const char gNotEntryText;
-extern const char gUnknown_80D418C;
-extern char gUnknown_80D41C4;
+extern const char gNotEntryText[];
+extern const char gUnknown_80D418C[];
+extern const char gUnknown_80D41C4[];
 
 void sub_8011760(void)
 {
@@ -172,55 +172,18 @@ void sub_8011930(u16 r0)
     sub_800BFD0(r0);
 }
 
-// TODO fix this nonmatching
-#ifndef NONMATCHING
-NAKED
-#endif
 u32 sub_8011940(u16 r0)
 {
-#ifdef NONMATCHING
     u32 temp;
     temp = sub_800C068();
 
-    if(r0 == 0x3e7)
+    if(r0 == 999)
     {
-        temp ^= r0;
-        // TODO this OR/NEG apparently is close
-        temp |= -temp;
-        return temp >> 31;
+        temp ^= 999;
+        return (-temp | temp) >> 31;
     }
 
-    if(temp != r0)
-        return 0;
-    else
-        return 1;
-#else
-	asm_unified("\tpush {r4,lr}\n"
-	"\tlsls r0, 16\n"
-	"\tlsrs r4, r0, 16\n"
-	"\tbl sub_800C068\n"
-	"\tlsls r0, 16\n"
-	"\tlsrs r1, r0, 16\n"
-	"\tldr r0, _08011960\n"
-	"\tcmp r4, r0\n"
-	"\tbne _08011964\n"
-	"\teors r1, r4\n"
-	"\tnegs r0, r1\n"
-	"\torrs r0, r1\n"
-	"\tlsrs r0, 31\n"
-	"\tb _0801196C\n"
-        "\t.align 2,0\n"
-        "_08011960: .4byte 0x000003e7\n"
-        "_08011964:\n"
-        "\tmovs r0, 0\n"
-        "\tcmp r1, r4\n"
-        "\tbne _0801196C\n"
-        "\tmovs r0, 0x1\n"
-        "_0801196C:\n"
-        "\tpop {r4}\n"
-        "\tpop {r1}\n"
-        "\tbx r1");
-#endif
+    return temp == r0;
 }
 
 void sub_8011974(u16 r0, u16 r1)
@@ -289,68 +252,20 @@ void nullsub_26(void)
 {
 }
 
-#ifndef NONMATCHING
-NAKED
-#endif
 // Unused
-void PrintFuncFileLineOrNotEntry(char * r0, struct unkFileStruct *r1)
+void PrintFuncFileLineOrNotEntry(char * r0, struct DebugLocation *r1)
 {
-#ifdef NONMATCHING
-    u32 temp;
     if(r1 != 0)
     {
-        // TODO fix regswap here.. otherwise looks good
-        temp = r1->unk4;
-        sprintf(r0, &gUnknown_80D418C, r1->unk8, r1->unk0, temp);
+        sprintf(r0, gUnknown_80D418C, r1->func, r1->file, r1->line);
     }
     else
     {
-        sprintf(r0, &gNotEntryText);
+        sprintf(r0, gNotEntryText);
     }
-#else
-	asm_unified("\tpush {r4,lr}\n"
-	"\tsub sp, 0x4\n"
-	"\tadds r4, r0, 0\n"
-	"\tadds r0, r1, 0\n"
-	"\tcmp r0, 0\n"
-	"\tbeq _08011A90\n"
-	"\tldr r1, _08011A8C\n"
-	"\tldr r2, [r0, 0x8]\n"
-	"\tldr r3, [r0]\n"
-	"\tldr r0, [r0, 0x4]\n"
-	"\tstr r0, [sp]\n"
-	"\tadds r0, r4, 0\n"
-	"\tbl sprintf\n"
-	"\tb _08011A98\n"
-	"\t.align 2, 0\n"
-"_08011A8C: .4byte gUnknown_80D418C\n"
-"_08011A90:\n"
-	"\tldr r1, _08011AA0\n"
-	"\tadds r0, r4, 0\n"
-	"\tbl sprintf\n"
-"_08011A98:\n"
-	"\tadd sp, 0x4\n"
-	"\tpop {r4}\n"
-	"\tpop {r0}\n"
-	"\tbx r0\n"
-	"\t.align 2, 0\n"
-"_08011AA0: .4byte gNotEntryText");
-#endif
 }
 
-void PrintFuncFileLine(char *r0, struct unkFileStruct *r1, u32 r2)
+void PrintFuncFileLine(char *buf, struct DebugLocation *loc, char* prefix)
 {
-    volatile u32 temp;
-    volatile u32 temp2;
-    u32 r3;
-    u32 r4;
-    char *preload;
-
-    preload = &gUnknown_80D41C4;
-    r3 = r1->unk8;
-    r4 = r1->unk0;
-    temp = r4;
-    temp2 = r1->unk4;
-
-    sprintf(r0, preload, r2, r3);
+    sprintf(buf, gUnknown_80D41C4, prefix, loc->func, loc->file, loc->line);
 }

--- a/src/code_80118A4_1.c
+++ b/src/code_80118A4_1.c
@@ -23,40 +23,10 @@ void sub_8011B14(void)
     gUnknown_203B150 = 0;
 }
 
-#ifndef NONMATCHING
-NAKED
-#endif
 u8 sub_8011B20(void)
 {
-#ifdef NONMATCHING
-    // TODO figure out why I mix up my mv/ldr for these kinds of comparisons
-    u8 temp;
-    if(gUnknown_203B150 == 0)
-    {
-        temp = 1;
-    }
-    else
-    {
-        temp = 0;
-    }
-    gUnknown_203B150 = temp;
+    gUnknown_203B150 = !gUnknown_203B150;
     return gUnknown_203B150;
-#else
-	asm_unified("\tpush {lr}\n"
-	"\tldr r1, _08011B38\n"
-	"\tmovs r2, 0\n"
-	"\tldrb r0, [r1]\n"
-	"\tcmp r0, 0\n"
-	"\tbne _08011B2E\n"
-	"\tmovs r2, 0x1\n"
-"_08011B2E:\n"
-	"\tstrb r2, [r1]\n"
-	"\tldrb r0, [r1]\n"
-	"\tpop {r1}\n"
-	"\tbx r1\n"
-	"\t.align 2, 0\n"
-"_08011B38: .4byte gUnknown_203B150");
-#endif
 }
 
 // unused

--- a/src/music.c
+++ b/src/music.c
@@ -99,12 +99,8 @@ void nullsub_179(void)
 {
 }
 
-#ifndef NONMATCHING
-NAKED
-#endif
 u8 sub_800CA38(u32 songIndex)
 {
-#ifdef NONMATCHING
     if(IsBGSong(songIndex))
     {
         if(sub_800CAE0(songIndex) == 0)
@@ -114,70 +110,19 @@ u8 sub_800CA38(u32 songIndex)
     }
     if(sub_800CACC(songIndex))
     {
-        // TODO compiler gets weird here wanted to skip to next check
         if(sub_800CAE0(songIndex) == 1)
         {
-    _0800CA70: 
             return 1;
         }
     }
-    if(sub_800CAAC(songIndex))
+    else if(sub_800CAAC(songIndex))
     {
-        if((sub_800CAE0(songIndex) > 1))
+        if(sub_800CAE0(songIndex) > 1)
         {
-            goto _0800CA70;
+            return 1;
         }
     }
     return 0;
-#else
-	asm_unified("\tpush {r4,lr}\n"
-	"\tadds r4, r0, 0\n"
-	"\tbl IsBGSong\n"
-	"\tlsls r0, 24\n"
-	"\tcmp r0, 0\n"
-	"\tbeq _0800CA54\n"
-	"\tlsls r0, r4, 16\n"
-	"\tlsrs r0, 16\n"
-	"\tbl sub_800CAE0\n"
-	"\tlsls r0, 16\n"
-	"\tcmp r0, 0\n"
-	"\tbeq _0800CA70\n"
-"_0800CA54:\n"
-	"\tadds r0, r4, 0\n"
-	"\tbl sub_800CACC\n"
-	"\tlsls r0, 24\n"
-	"\tcmp r0, 0\n"
-	"\tbeq _0800CA74\n"
-	"\tlsls r0, r4, 16\n"
-	"\tlsrs r0, 16\n"
-	"\tbl sub_800CAE0\n"
-	"\tlsls r0, 16\n"
-	"\tlsrs r0, 16\n"
-	"\tcmp r0, 0x1\n"
-	"\tbne _0800CA90\n"
-"_0800CA70:\n"
-	"\tmovs r0, 0x1\n"
-	"\tb _0800CA92\n"
-"_0800CA74:\n"
-	"\tadds r0, r4, 0\n"
-	"\tbl sub_800CAAC\n"
-	"\tlsls r0, 24\n"
-	"\tcmp r0, 0\n"
-	"\tbeq _0800CA90\n"
-	"\tlsls r0, r4, 16\n"
-	"\tlsrs r0, 16\n"
-	"\tbl sub_800CAE0\n"
-	"\tlsls r0, 16\n"
-	"\tlsrs r0, 16\n"
-	"\tcmp r0, 0x1\n"
-	"\tbhi _0800CA70\n"
-"_0800CA90:\n"
-	"\tmovs r0, 0\n"
-"_0800CA92:\n"
-	"\tpop {r4}\n"
-	"\tpop {r1}\n"
-	"\tbx r1");
-#endif
 }
 
 void nullsub_19(void)

--- a/src/pokemon_1.c
+++ b/src/pokemon_1.c
@@ -6,7 +6,7 @@ extern int sprintf(char *, const char *, ...);
 
 extern struct gPokemon *gMonsterParameters;
 extern struct FileArchive gUnknown_8510000;
-extern const char gUnknown_8107684;
+extern const char gUnknown_8107684[];
 
 struct unkEvolve
 {
@@ -14,35 +14,16 @@ struct unkEvolve
     /* 0x4 */ struct EvolveNeeds needs;
 };
 
-#ifndef NONMATCHING
-NAKED
-#endif
-void sub_808DD48(s16 r0, struct unkEvolve *r1)
+s16 sub_808DD48(s16 r0, struct unkEvolve *r1)
 {
-#ifdef NONMATCHING
     struct EvolveStruct1 temp2;
     struct EvolveNeeds temp1;
     temp1 = gMonsterParameters[r0].need;
-    temp2 = gMonsterParameters[r0].pre; // TODO should be using r2 but it uses r0
+    temp2 = gMonsterParameters[r0].pre;
     r1->conditions = temp2;
     r1->needs = temp1;
-#else
-	asm_unified("\tlsls r0, 16\n"
-	"\tasrs r0, 16\n"
-	"\tldr r2, _0808DD64\n"
-	"\tldr r3, [r2]\n"
-	"\tlsls r2, r0, 3\n"
-	"\tadds r2, r0\n"
-	"\tlsls r2, 3\n"
-	"\tadds r2, r3\n"
-	"\tldr r3, [r2, 0x38]\n"
-	"\tldr r2, [r2, 0x34]\n"
-	"\tstr r2, [r1]\n"
-	"\tstr r3, [r1, 0x4]\n"
-	"\tbx lr\n"
-	"\t.align 2, 0\n"
-"_0808DD64: .4byte gMonsterParameters");
-#endif
+    // The return value is not used anywhere, but necessary for the function to match.
+    return r0;
 }
 
 u8 sub_808DD68(s16 r0, u32 r1)
@@ -60,106 +41,30 @@ u8 sub_808DD68(s16 r0, u32 r1)
     }
 }
 
-#ifndef NONMATCHING
-NAKED
-#endif
 struct OpenedFile *sub_808DD90(s16 r0)
 {
-#ifdef NONMATCHING
     // Looks like this loads the dialogue sprite for the pokemon
 
-    // Two words: register memes... else it matches
-    // Fix this and then one after matches too
     char buffer[0xC];
     if(gMonsterParameters[r0].dialogue_sprites == 0)
     {
         return NULL;
     }
-    sprintf(buffer, &gUnknown_8107684);
+    sprintf(buffer, gUnknown_8107684, r0); // "kao%03d"
     return OpenFile(buffer, &gUnknown_8510000);
-#else
-	asm_unified("\tpush {lr}\n"
-	"\tsub sp, 0xC\n"
-	"\tlsls r0, 16\n"
-	"\tasrs r2, r0, 16\n"
-	"\tldr r0, _0808DDBC\n"
-	"\tldr r1, [r0]\n"
-	"\tlsls r0, r2, 3\n"
-	"\tadds r0, r2\n"
-	"\tlsls r0, 3\n"
-	"\tadds r0, r1\n"
-	"\tldrh r0, [r0, 0x10]\n"
-	"\tcmp r0, 0\n"
-	"\tbeq _0808DDC8\n"
-	"\tldr r1, _0808DDC0\n"
-	"\tmov r0, sp\n"
-	"\tbl sprintf\n"
-	"\tldr r1, _0808DDC4\n"
-	"\tmov r0, sp\n"
-	"\tbl OpenFile\n"
-	"\tb _0808DDCA\n"
-	"\t.align 2, 0\n"
-"_0808DDBC: .4byte gMonsterParameters\n"
-"_0808DDC0: .4byte gUnknown_8107684\n"
-"_0808DDC4: .4byte gUnknown_8510000\n"
-"_0808DDC8:\n"
-	"\tmovs r0, 0\n"
-"_0808DDCA:\n"
-	"\tadd sp, 0xC\n"
-	"\tpop {r1}\n"
-	"\tbx r1");
-#endif
 }
 
-#ifndef NONMATCHING
-NAKED
-#endif
 struct OpenedFile *sub_808DDD0(s16 r0)
 {
-#ifdef NONMATCHING
     // Looks like this loads the dialogue sprite for the pokemon
 
-    // Two words: register memes... else it matches
     char buffer[0xC];
     if(gMonsterParameters[r0].dialogue_sprites == 0)
     {
         return NULL;
     }
-    sprintf(buffer, &gUnknown_8107684);
+    sprintf(buffer, gUnknown_8107684, r0); // "kao%03d"
     return OpenFileAndGetFileDataPtr(buffer, &gUnknown_8510000);
-#else
-	asm_unified("\tpush {lr}\n"
-	"\tsub sp, 0xC\n"
-	"\tlsls r0, 16\n"
-	"\tasrs r2, r0, 16\n"
-	"\tldr r0, _0808DDFC\n"
-	"\tldr r1, [r0]\n"
-	"\tlsls r0, r2, 3\n"
-	"\tadds r0, r2\n"
-	"\tlsls r0, 3\n"
-	"\tadds r0, r1\n"
-	"\tldrh r0, [r0, 0x10]\n"
-	"\tcmp r0, 0\n"
-	"\tbeq _0808DE08\n"
-	"\tldr r1, _0808DE00\n"
-	"\tmov r0, sp\n"
-	"\tbl sprintf\n"
-	"\tldr r1, _0808DE04\n"
-	"\tmov r0, sp\n"
-	"\tbl OpenFileAndGetFileDataPtr\n"
-	"\tb _0808DE0A\n"
-	"\t.align 2, 0\n"
-        "_0808DDFC: .4byte gMonsterParameters\n"
-        "_0808DE00: .4byte gUnknown_8107684\n"
-        "_0808DE04: .4byte gUnknown_8510000\n"
-        "_0808DE08:\n"
-	"\tmovs r0, 0\n"
-        "_0808DE0A:\n"
-	"\tadd sp, 0xC\n"
-	"\tpop {r1}\n"
-	"\tbx r1");
-
-#endif
 }
 
 bool8 sub_808DE10(s16 r0, s32 r1)


### PR DESCRIPTION
Some of them were plain wrong code, such as missing arguments to sprintf (no wonder it wouldn't match).
A lot of others seem to be caused by an attempt to take up the maximum possible amount of vertical space, breaking up simple expressions into imperative if-else conditions with temporaries, while using the braces style that AGAIN maximizes the amount of vertical space used.
Just look at `sub_8011B20` - the branch in the C version was longer than the assembly for that branch!